### PR TITLE
Fix for xss in netlify-cms-widget-markdown

### DIFF
--- a/packages/netlify-cms-widget-markdown/package.json
+++ b/packages/netlify-cms-widget-markdown/package.json
@@ -1,28 +1,35 @@
 {
-  "name": "netlify-cms-widget-markdown",
-  "description": "Widget for editing markdown in Netlify CMS.",
-  "version": "2.12.8",
-  "homepage": "https://www.netlifycms.org/docs/widgets/#markdown",
-  "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-widget-markdown",
-  "bugs": "https://github.com/netlify/netlify-cms/issues",
-  "module": "dist/esm/index.js",
-  "main": "dist/netlify-cms-widget-markdown.js",
-  "license": "MIT",
-  "keywords": [
-    "netlify",
-    "netlify-cms",
-    "widget",
-    "markdown",
-    "editor"
-  ],
-  "sideEffects": false,
-  "scripts": {
-    "develop": "yarn build:esm --watch",
-    "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
+  "_from": "netlify-cms-widget-markdown@^2.12.8",
+  "_id": "netlify-cms-widget-markdown@2.12.8",
+  "_inBundle": false,
+  "_integrity": "sha512-ndgzjNBd/3JBO5Te7gfZgYdxJxR94GKGfH0mq3iLKBkiVtz+WLqV3372QaCea4QkVuoGdRlBqi1KH5CGBWqepg==",
+  "_location": "/netlify-cms-widget-markdown",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "range",
+    "registry": true,
+    "raw": "netlify-cms-widget-markdown@^2.12.8",
+    "name": "netlify-cms-widget-markdown",
+    "escapedName": "netlify-cms-widget-markdown",
+    "rawSpec": "^2.12.8",
+    "saveSpec": null,
+    "fetchSpec": "^2.12.8"
   },
+  "_requiredBy": [
+    "/netlify-cms-app"
+  ],
+  "_resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.12.8.tgz",
+  "_shasum": "6d3e39730c333b7462ed638640d4669f9f3b0a4d",
+  "_spec": "netlify-cms-widget-markdown@^2.12.8",
+  "_where": "/home/b3ef_/opensource/huntr/fix/xss/huntr-hugo-cms/node_modules/netlify-cms-app",
+  "bugs": {
+    "url": "https://github.com/netlify/netlify-cms/issues"
+  },
+  "bundleDependencies": false,
   "dependencies": {
+    "dompurify": "^2.2.6",
     "is-hotkey": "^0.2.0",
+    "jsdom": "^16.4.0",
     "mdast-util-definitions": "^1.2.3",
     "mdast-util-to-string": "^1.0.5",
     "react-select": "^2.4.3",
@@ -41,6 +48,26 @@
     "unist-builder": "^1.0.3",
     "unist-util-visit-parents": "^2.0.1"
   },
+  "deprecated": false,
+  "description": "Widget for editing markdown in Netlify CMS.",
+  "devDependencies": {
+    "commonmark": "^0.29.0",
+    "commonmark-spec": "^0.29.0",
+    "slate-hyperscript": "^0.13.3"
+  },
+  "gitHead": "74d5569bd3daf7cb878435432d9d4545001e7f82",
+  "homepage": "https://www.netlifycms.org/docs/widgets/#markdown",
+  "keywords": [
+    "netlify",
+    "netlify-cms",
+    "widget",
+    "markdown",
+    "editor"
+  ],
+  "license": "MIT",
+  "main": "dist/netlify-cms-widget-markdown.js",
+  "module": "dist/esm/index.js",
+  "name": "netlify-cms-widget-markdown",
   "peerDependencies": {
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
@@ -52,9 +79,15 @@
     "react-dom": "^16.8.4",
     "react-immutable-proptypes": "^2.1.0"
   },
-  "devDependencies": {
-    "commonmark": "^0.29.0",
-    "commonmark-spec": "^0.29.0",
-    "slate-hyperscript": "^0.13.3"
-  }
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-widget-markdown"
+  },
+  "scripts": {
+    "build": "cross-env NODE_ENV=production webpack",
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward",
+    "develop": "yarn build:esm --watch"
+  },
+  "sideEffects": false,
+  "version": "2.12.8"
 }

--- a/packages/netlify-cms-widget-markdown/package.json
+++ b/packages/netlify-cms-widget-markdown/package.json
@@ -1,35 +1,30 @@
 {
-  "_from": "netlify-cms-widget-markdown@^2.12.8",
-  "_id": "netlify-cms-widget-markdown@2.12.8",
-  "_inBundle": false,
-  "_integrity": "sha512-ndgzjNBd/3JBO5Te7gfZgYdxJxR94GKGfH0mq3iLKBkiVtz+WLqV3372QaCea4QkVuoGdRlBqi1KH5CGBWqepg==",
-  "_location": "/netlify-cms-widget-markdown",
-  "_phantomChildren": {},
-  "_requested": {
-    "type": "range",
-    "registry": true,
-    "raw": "netlify-cms-widget-markdown@^2.12.8",
-    "name": "netlify-cms-widget-markdown",
-    "escapedName": "netlify-cms-widget-markdown",
-    "rawSpec": "^2.12.8",
-    "saveSpec": null,
-    "fetchSpec": "^2.12.8"
-  },
-  "_requiredBy": [
-    "/netlify-cms-app"
+  "name": "netlify-cms-widget-markdown",
+  "description": "Widget for editing markdown in Netlify CMS.",
+  "version": "2.12.8",
+  "homepage": "https://www.netlifycms.org/docs/widgets/#markdown",
+  "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-widget-markdown",
+  "bugs": "https://github.com/netlify/netlify-cms/issues",
+  "module": "dist/esm/index.js",
+  "main": "dist/netlify-cms-widget-markdown.js",
+  "license": "MIT",
+  "keywords": [
+    "netlify",
+    "netlify-cms",
+    "widget",
+    "markdown",
+    "editor"
   ],
-  "_resolved": "https://registry.npmjs.org/netlify-cms-widget-markdown/-/netlify-cms-widget-markdown-2.12.8.tgz",
-  "_shasum": "6d3e39730c333b7462ed638640d4669f9f3b0a4d",
-  "_spec": "netlify-cms-widget-markdown@^2.12.8",
-  "_where": "/home/b3ef_/opensource/huntr/fix/xss/huntr-hugo-cms/node_modules/netlify-cms-app",
-  "bugs": {
-    "url": "https://github.com/netlify/netlify-cms/issues"
+  "sideEffects": false,
+  "scripts": {
+    "develop": "yarn build:esm --watch",
+    "build": "cross-env NODE_ENV=production webpack",
+    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward"
   },
-  "bundleDependencies": false,
   "dependencies": {
     "dompurify": "^2.2.6",
-    "is-hotkey": "^0.2.0",
     "jsdom": "^16.4.0",
+    "is-hotkey": "^0.2.0",
     "mdast-util-definitions": "^1.2.3",
     "mdast-util-to-string": "^1.0.5",
     "react-select": "^2.4.3",
@@ -48,26 +43,6 @@
     "unist-builder": "^1.0.3",
     "unist-util-visit-parents": "^2.0.1"
   },
-  "deprecated": false,
-  "description": "Widget for editing markdown in Netlify CMS.",
-  "devDependencies": {
-    "commonmark": "^0.29.0",
-    "commonmark-spec": "^0.29.0",
-    "slate-hyperscript": "^0.13.3"
-  },
-  "gitHead": "74d5569bd3daf7cb878435432d9d4545001e7f82",
-  "homepage": "https://www.netlifycms.org/docs/widgets/#markdown",
-  "keywords": [
-    "netlify",
-    "netlify-cms",
-    "widget",
-    "markdown",
-    "editor"
-  ],
-  "license": "MIT",
-  "main": "dist/netlify-cms-widget-markdown.js",
-  "module": "dist/esm/index.js",
-  "name": "netlify-cms-widget-markdown",
   "peerDependencies": {
     "@emotion/core": "^10.0.35",
     "@emotion/styled": "^10.0.27",
@@ -79,15 +54,9 @@
     "react-dom": "^16.8.4",
     "react-immutable-proptypes": "^2.1.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-widget-markdown"
-  },
-  "scripts": {
-    "build": "cross-env NODE_ENV=production webpack",
-    "build:esm": "cross-env NODE_ENV=esm babel src --out-dir dist/esm --ignore \"**/__tests__\" --root-mode upward",
-    "develop": "yarn build:esm --watch"
-  },
-  "sideEffects": false,
-  "version": "2.12.8"
+  "devDependencies": {
+    "commonmark": "^0.29.0",
+    "commonmark-spec": "^0.29.0",
+    "slate-hyperscript": "^0.13.3"
+  }
 }

--- a/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownPreview.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { WidgetPreviewContainer } from 'netlify-cms-ui-default';
 import { markdownToHtml } from './serializers';
-
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
 class MarkdownPreview extends React.Component {
   static propTypes = {
     getAsset: PropTypes.func.isRequired,
@@ -16,7 +19,7 @@ class MarkdownPreview extends React.Component {
       return null;
     }
 
-    const html = markdownToHtml(value, { getAsset, resolveWidget });
+    const html = DOMPurify.sanitize(markdownToHtml(value, { getAsset, resolveWidget }));
 
     return <WidgetPreviewContainer dangerouslySetInnerHTML={{ __html: html }} />;
   }


### PR DESCRIPTION
### 📊 Metadata *

Fixed xss in netlify-cms-widget-markdown

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-netlify-cms-widget-markdown

### ⚙️ Description *

XSS was Caused due to the unsanitized rendering of markdown codes to HTML preview. The fix is done with dompurify sanitize function with the help of jsdom dependency.
### 💻 Technical Description *
the issue caused by code at line number 19.
### 🐛 Proof of Concept (POC) *
![](https://cdn.discordapp.com/attachments/791939790069170206/791939867562868757/Screenshot_from_2020-12-25_13-35-44.png)
* After applying the fixed code remove node_modules from .gitignore and push it into your GitHub repo so that netlify can rebuild your project. 
### 🔥 Proof of Fix (PoF) *
![](https://cdn.discordapp.com/attachments/791939790069170206/792080743332446218/Screenshot_from_2020-12-25_22-06-17.png)
### 👍 User Acceptance Testing (UAT)
The program has been run successfully